### PR TITLE
Fixed js_url definition with a String() object

### DIFF
--- a/jsmol_bokeh_extension/jsmol.py
+++ b/jsmol_bokeh_extension/jsmol.py
@@ -39,4 +39,4 @@ class JSMol(LayoutDOM):
     # Path to JSMol javascript file (can be full or relative URL), e.g.
     # e.g. https://chemapps.stolaf.edu/jmol/jsmol/JSmol.min.js
     # or jsmol/JSmol.min.js
-    js_url = String
+    js_url = String()


### PR DESCRIPTION
This fixes issue https://github.com/ltalirz/jsmol-bokeh-extension/issues/8 (in order to also fix https://github.com/dgarayr/amk_tools/issues/3), by correcting the definition of the js_url constructor in jsmol.py.